### PR TITLE
Add code exclusion to generator and pool

### DIFF
--- a/src/CrockfordRandom.php
+++ b/src/CrockfordRandom.php
@@ -11,18 +11,44 @@ final class CrockfordRandom
 {
     private const string ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
-    public static function generate(int $length): string
+    /**
+     * @param list<string> $exclude Codes that must not be returned (case-insensitive).
+     *                              Retries up to $maxAttempts before throwing.
+     */
+    public static function generate(int $length, array $exclude = [], int $maxAttempts = 100): string
     {
         if ($length <= 0) {
             throw new ValueError('Length must be positive');
         }
 
         $randomizer = new Randomizer();
-        return $randomizer->getBytesFromString(self::ALPHABET, $length);
+
+        if ($exclude === []) {
+            return $randomizer->getBytesFromString(self::ALPHABET, $length);
+        }
+
+        $excludeSet = [];
+        foreach ($exclude as $code) {
+            $excludeSet[strtoupper($code)] = true;
+        }
+
+        for ($i = 0; $i < $maxAttempts; $i++) {
+            $code = $randomizer->getBytesFromString(self::ALPHABET, $length);
+            if (!isset($excludeSet[$code])) {
+                return $code;
+            }
+        }
+
+        throw new \RuntimeException(
+            sprintf('Could not generate a non-excluded code of length %d after %d attempts.', $length, $maxAttempts)
+        );
     }
 
-    public static function generateLowercase(int $length): string
+    /**
+     * @param list<string> $exclude
+     */
+    public static function generateLowercase(int $length, array $exclude = [], int $maxAttempts = 100): string
     {
-        return strtolower(self::generate($length));
+        return strtolower(self::generate($length, $exclude, $maxAttempts));
     }
 }

--- a/src/UniqueCrockfordPool.php
+++ b/src/UniqueCrockfordPool.php
@@ -16,6 +16,9 @@ final class UniqueCrockfordPool
     /** @var array<string, true> Used as a set for O(1) lookups. */
     private array $storage;
 
+    /** @var array<string, true> Pre-excluded codes that must never be issued. */
+    private array $excluded;
+
     /**
      * Maximum length that can be handled with native PHP int (32^12 < PHP_INT_MAX).
      * For lengths > 12, brick/math is required.
@@ -24,8 +27,11 @@ final class UniqueCrockfordPool
 
     /**
      * Create a pool that yields unique Crockford Base32 codes of fixed $length.
+     *
+     * @param list<string> $exclude Codes to exclude from issuance up front (e.g. codes you already
+     *                              issued elsewhere). Normalized to uppercase. Each must match $length.
      */
-    public function __construct(private readonly int $length)
+    public function __construct(private readonly int $length, array $exclude = [])
     {
         if ($length <= 0) {
             throw new InvalidLength('Length must be positive.');
@@ -44,6 +50,43 @@ final class UniqueCrockfordPool
         }
 
         $this->storage = [];
+        $this->excluded = [];
+
+        if ($exclude !== []) {
+            $this->exclude($exclude);
+        }
+    }
+
+    /**
+     * Exclude additional codes from future issuance. Codes are normalized to uppercase.
+     * Calling this with already-excluded or already-issued codes is a no-op for those entries.
+     *
+     * @param list<string> $codes
+     * @throws InvalidLength If any code does not match the pool's length.
+     */
+    public function exclude(array $codes): void
+    {
+        $normalized = [];
+        foreach ($codes as $code) {
+            if (strlen($code) !== $this->length) {
+                throw new InvalidLength(
+                    sprintf('Excluded code %s does not match pool length %d.', $code, $this->length)
+                );
+            }
+            $normalized[strtoupper($code)] = true;
+        }
+
+        // Capacity sanity check (only for native-size pools; huge pools can't overflow in practice).
+        if ($this->length <= self::MAX_NATIVE_LENGTH) {
+            $taken = count($this->storage + $this->excluded + $normalized);
+            if ($taken > $this->capacityInt()) {
+                throw new PoolExhausted(
+                    sprintf('Excluding these codes would exceed pool capacity of %d.', $this->capacityInt())
+                );
+            }
+        }
+
+        $this->excluded += $normalized;
     }
 
     /**
@@ -62,7 +105,7 @@ final class UniqueCrockfordPool
 
         do {
             $code = CrockfordRandom::generate($this->length);
-        } while ($this->hasIssued($code));
+        } while (isset($this->storage[$code]) || isset($this->excluded[$code]));
 
         $this->storage[$code] = true;
         return $code;
@@ -146,10 +189,26 @@ final class UniqueCrockfordPool
             return false;
         }
 
-        $issued = $this->issuedCount();
-        
+        $taken = $this->issuedCount() + $this->excludedCount();
+
         // Use native int comparison for small pools
-        return $issued >= $this->capacityInt();
+        return $taken >= $this->capacityInt();
+    }
+
+    /**
+     * Number of pre-excluded codes (never issued by this pool).
+     */
+    public function excludedCount(): int
+    {
+        return count($this->excluded);
+    }
+
+    /**
+     * Returns true if the given code (case-insensitive) is in the excluded set.
+     */
+    public function isExcluded(string $code): bool
+    {
+        return isset($this->excluded[strtoupper($code)]);
     }
 
     /**
@@ -158,12 +217,13 @@ final class UniqueCrockfordPool
      */
     public function remaining(): int
     {
-        return $this->capacityInt() - $this->issuedCount();
+        return $this->capacityInt() - $this->issuedCount() - $this->excludedCount();
     }
 
     public function remainingBigInt(): \Brick\Math\BigInteger
     {
-        return \Brick\Math\BigInteger::of($this->capacityString())->minus(\Brick\Math\BigInteger::of($this->issuedCount()));
+        return \Brick\Math\BigInteger::of($this->capacityString())
+            ->minus(\Brick\Math\BigInteger::of($this->issuedCount() + $this->excludedCount()));
     }
 
     /**
@@ -198,12 +258,12 @@ final class UniqueCrockfordPool
             throw new InvalidLength('Count must be positive.');
         }
 
-        // Check if reservation would exceed capacity
-        $issued = $this->issuedCount();
-        
+        // Check if reservation would exceed capacity (excluded codes count against capacity too)
+        $taken = $this->issuedCount() + $this->excludedCount();
+
         if ($this->length <= self::MAX_NATIVE_LENGTH) {
             // Use native int for small pools
-            if ($issued + $count > $this->capacityInt()) {
+            if ($taken + $count > $this->capacityInt()) {
                 throw new PoolExhausted(
                     sprintf("Reserving %d codes would exceed pool capacity of %d.", $count, $this->capacityInt())
                 );
@@ -211,7 +271,7 @@ final class UniqueCrockfordPool
         } else {
 
             /** @var \Brick\Math\BigInteger $of */
-            $of = \Brick\Math\BigInteger::of((string) $issued);
+            $of = \Brick\Math\BigInteger::of((string) $taken);
 
             /** @var \Brick\Math\BigInteger $issuedPlusCount */
             $issuedPlusCount = $of->plus(\Brick\Math\BigInteger::of((string) $count));

--- a/src/UniqueCrockfordPool.php
+++ b/src/UniqueCrockfordPool.php
@@ -66,27 +66,14 @@ final class UniqueCrockfordPool
      */
     public function exclude(array $codes): void
     {
-        $normalized = [];
         foreach ($codes as $code) {
             if (strlen($code) !== $this->length) {
                 throw new InvalidLength(
                     sprintf('Excluded code %s does not match pool length %d.', $code, $this->length)
                 );
             }
-            $normalized[strtoupper($code)] = true;
+            $this->excluded[strtoupper($code)] = true;
         }
-
-        // Capacity sanity check (only for native-size pools; huge pools can't overflow in practice).
-        if ($this->length <= self::MAX_NATIVE_LENGTH) {
-            $taken = count($this->storage + $this->excluded + $normalized);
-            if ($taken > $this->capacityInt()) {
-                throw new PoolExhausted(
-                    sprintf('Excluding these codes would exceed pool capacity of %d.', $this->capacityInt())
-                );
-            }
-        }
-
-        $this->excluded += $normalized;
     }
 
     /**

--- a/tests/Unit/CrockfordRandomTest.php
+++ b/tests/Unit/CrockfordRandomTest.php
@@ -139,4 +139,35 @@ class CrockfordRandomTest extends TestCase
             'Multiple calls should produce different results (got ' . count($uniqueResults) . ' unique out of 10)'
         );
     }
+
+    public function testGenerateRespectsExclusions(): void
+    {
+        // Length 1 with 31 of 32 codes excluded forces the only remaining code.
+        $exclude = str_split('123456789ABCDEFGHJKMNPQRSTVWXYZ');
+        $result = CrockfordRandom::generate(1, $exclude);
+        self::assertSame('0', $result);
+    }
+
+    public function testGenerateExclusionIsCaseInsensitive(): void
+    {
+        // Exclude lowercase — generator output is uppercase — still should be honored.
+        $exclude = str_split('123456789abcdefghjkmnpqrstvwxyz');
+        $result = CrockfordRandom::generate(1, $exclude);
+        self::assertSame('0', $result);
+    }
+
+    public function testGenerateThrowsWhenAllExcluded(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not generate a non-excluded code of length 1 after 50 attempts.');
+
+        CrockfordRandom::generate(1, str_split('0123456789ABCDEFGHJKMNPQRSTVWXYZ'), 50);
+    }
+
+    public function testGenerateLowercaseRespectsExclusions(): void
+    {
+        $exclude = str_split('123456789ABCDEFGHJKMNPQRSTVWXYZ');
+        $result = CrockfordRandom::generateLowercase(1, $exclude);
+        self::assertSame('0', $result);
+    }
 }

--- a/tests/Unit/UniqueCrockfordPoolTest.php
+++ b/tests/Unit/UniqueCrockfordPoolTest.php
@@ -340,6 +340,100 @@ class UniqueCrockfordPoolTest extends TestCase
         self::assertSame(1, $pool->issuedCount());
     }
 
+    public function testConstructorAcceptsExcludedCodes(): void
+    {
+        $pool = new UniqueCrockfordPool(5, ['ABCDE', 'fghjk']);
+
+        self::assertSame(0, $pool->issuedCount());
+        self::assertSame(2, $pool->excludedCount());
+        self::assertTrue($pool->isExcluded('ABCDE'));
+        self::assertTrue($pool->isExcluded('abcde'), 'Should be case-insensitive');
+        self::assertTrue($pool->isExcluded('FGHJK'), 'Lowercase input should be normalized');
+        self::assertFalse($pool->hasIssued('ABCDE'), 'Excluded codes are not "issued"');
+    }
+
+    public function testConstructorThrowsOnMismatchedExcludedCodeLength(): void
+    {
+        $this->expectException(InvalidLength::class);
+        $this->expectExceptionMessage('Excluded code ABC does not match pool length 5.');
+
+        new UniqueCrockfordPool(5, ['ABC']);
+    }
+
+    public function testExcludeMethodAddsCodes(): void
+    {
+        $pool = new UniqueCrockfordPool(5);
+        $pool->exclude(['ABCDE']);
+        $pool->exclude(['fghjk', 'MNPQR']);
+
+        self::assertSame(3, $pool->excludedCount());
+        self::assertTrue($pool->isExcluded('ABCDE'));
+        self::assertTrue($pool->isExcluded('FGHJK'));
+        self::assertTrue($pool->isExcluded('MNPQR'));
+    }
+
+    public function testExcludedCodesAreNeverIssued(): void
+    {
+        // Length 1, exclude 31 of 32 possible codes — only '0' remains.
+        $allButZero = [];
+        foreach (str_split('123456789ABCDEFGHJKMNPQRSTVWXYZ') as $char) {
+            $allButZero[] = $char;
+        }
+
+        $pool = new UniqueCrockfordPool(1, $allButZero);
+
+        self::assertSame(31, $pool->excludedCount());
+        self::assertSame(1, $pool->remaining());
+
+        $code = $pool->next();
+        self::assertSame('0', $code);
+
+        // Pool should now be exhausted.
+        $this->expectException(PoolExhausted::class);
+        $pool->next();
+    }
+
+    public function testExcludedCountReducesRemaining(): void
+    {
+        $pool = new UniqueCrockfordPool(1, ['A', 'B', 'C']);
+        self::assertSame(29, $pool->remaining()); // 32 - 3
+        $pool->next();
+        self::assertSame(28, $pool->remaining());
+    }
+
+    public function testReserveRespectsExcludedCapacity(): void
+    {
+        $pool = new UniqueCrockfordPool(1); // capacity 32
+        $pool->exclude(str_split('0123456789ABCDEFGHJKMNPQRSTVWXYZ')); // exclude all 32
+
+        $this->expectException(PoolExhausted::class);
+        $this->expectExceptionMessage('Reserving 1 codes would exceed pool capacity of 32.');
+        $pool->reserve(1);
+    }
+
+    public function testResetDoesNotForgetExcluded(): void
+    {
+        $pool = new UniqueCrockfordPool(5, ['ABCDE']);
+        $pool->next();
+
+        $pool->reset();
+
+        self::assertSame(0, $pool->issuedCount());
+        self::assertSame(1, $pool->excludedCount(), 'Excluded codes survive reset');
+        self::assertTrue($pool->isExcluded('ABCDE'));
+    }
+
+    public function testExcludeIsIdempotent(): void
+    {
+        $pool = new UniqueCrockfordPool(1);
+        $pool->exclude(str_split('0123456789ABCDEFGHJKMNPQRSTVWXYZ'));
+        self::assertSame(32, $pool->excludedCount());
+
+        // Re-excluding the same codes is a no-op.
+        $pool->exclude(['0', 'A']);
+        self::assertSame(32, $pool->excludedCount());
+    }
+
     private function assertMatchesPattern(string $code): void
     {
         for ($i = 0, $iMax = strlen($code); $i < $iMax; $i++) {


### PR DESCRIPTION
Allows pre-seeding codes to exclude from generation, useful when codes already exist elsewhere and you want to avoid collisions without relying on retry-on-insert.

- CrockfordRandom::generate() accepts $exclude + $maxAttempts
- UniqueCrockfordPool constructor accepts $exclude
- UniqueCrockfordPool::exclude() adds more at runtime
- excludedCount() / isExcluded() for inspection
- Excluded codes count against capacity and survive reset()